### PR TITLE
ReferenceError in rainbow due to undefined lolcat

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@
         var o = seed || rand(256);
         function eachLine() {
           i -= 1;
-          lolcat.options.seed = o + i;
+          module.options.seed = o + i;
         }
         return module.format(fn, string, eachLine);
     };


### PR DESCRIPTION
## Description

This PR fixes a `ReferenceError` occurring in the `rainbow` function where `lolcat` is referenced but not defined within the factory scope.

## Problem

Inside the UMD factory, the `rainbow` function contains:

```js
lolcat.options.seed = o + i;
```

However, `lolcat` is not defined in this scope. The module is internally referenced as `module`, and `lolcat` is only assigned externally (`root.lolcat = factory()`).

This results in:

```
ReferenceError: lolcat is not defined
```

## Solution

Replace the invalid reference to `lolcat` with `module`, which correctly refers to the internal object.

## Changes

```diff
module.rainbow = function render(fn, string, seed) {
  var i = 20;
  var o = seed || rand(256);

  function eachLine() {
    i -= 1;
-   lolcat.options.seed = o + i;
+   module.options.seed = o + i;
  }

  return module.format(fn, string, eachLine);
};
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rainbow seeding behavior to correctly apply per-line during iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->